### PR TITLE
Force bash_scripts/make_venv.sh to use python3.11

### DIFF
--- a/bash_scripts/run_sim.sh
+++ b/bash_scripts/run_sim.sh
@@ -12,6 +12,7 @@ cd
 cd /work/pi_vinod_vokkarane_uml_edu/git/sdn_simulator/
 
 # Make and activate virtual environment
+module load python/3.11.0
 ./bash_scripts/make_venv.sh venvs/unity_venv python3.11
 source venvs/unity_venv/venv/bin/activate
 


### PR DESCRIPTION
added line to module load line to force python3.11.0 use